### PR TITLE
Add support for Python 3.8a3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
     - 3.6
     - 3.7
     - 3.8-dev
-    - pypy2.7-6.0
-    - pypy3.5-6.0
+    - pypy
+    - pypy3
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls zope.testrunner

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
-sudo: false
 language: python
+dist: xenial
 python:
     - 2.7
     - 3.5
     - 3.6
-    - pypy
-    - pypy3
-matrix:
-    include:
-        - python: 3.7
-          dist: xenial
-          sudo: true
+    - 3.7
+    - 3.8-dev
+    - pypy2.7-6.0
+    - pypy3.5-6.0
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls zope.testrunner

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
   Depend on zope.interface >= 3.8.0.
   [jensens]
 
+- Add support for Python 3.8a3.
+  [icemac]
+
 2.1 (2018-11-06)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py35,
     py36,
     py37,
+    py38,
     pypy,
     pypy3,
     coverage,


### PR DESCRIPTION
And switch TravisCI to xenial as this will be the default be beginning of May,
see https://changelog.travis-ci.com/xenial-as-the-default-build-environment-is-coming-97772